### PR TITLE
Add ROS 2 checkerboard calibration node

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "numpy",
-    "opencv-contrib-python",
+    "opencv-contrib-python-headless",
+    "rclpy",
+    "sensor-msgs",
+    "std-msgs",
+    "std-srvs",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/xnodes/calibration/nodes/__init__.py
+++ b/src/xnodes/calibration/nodes/__init__.py
@@ -1,0 +1,5 @@
+"""Calibration node implementations."""
+
+from .checkerboard_calibrator import CheckerboardCalibratorNode
+
+__all__ = ["CheckerboardCalibratorNode"]

--- a/src/xnodes/calibration/nodes/checkerboard_calibrator.py
+++ b/src/xnodes/calibration/nodes/checkerboard_calibrator.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+import rclpy
+from builtin_interfaces.msg import Time
+from rclpy.node import Node
+from sensor_msgs.msg import CameraInfo, Image
+from std_srvs.srv import Trigger
+
+
+@dataclass
+class CalibrationResult:
+    matrix: np.ndarray
+    distortion: np.ndarray
+    rvecs: Sequence[np.ndarray]
+    tvecs: Sequence[np.ndarray]
+
+
+class CheckerboardCalibratorNode(Node):
+    """Calibrates a monocular camera from checkerboard image streams."""
+
+    def __init__(self, node_name: str = "checkerboard_calibrator", **node_kwargs: object) -> None:
+        super().__init__(node_name, **node_kwargs)
+        cols = self.declare_parameter("checkerboard_cols", 6).value
+        rows = self.declare_parameter("checkerboard_rows", 9).value
+        self._checkerboard = (int(cols), int(rows))
+        square_size = float(self.declare_parameter("square_size", 1.0).value)
+        self._criteria = (
+            cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER,
+            int(self.declare_parameter("corner_refinement_iters", 30).value),
+            float(self.declare_parameter("corner_refinement_eps", 1e-3).value),
+        )
+        self._required_samples = int(self.declare_parameter("required_samples", 20).value)
+        self._fast_check = bool(self.declare_parameter("use_fast_check", False).value)
+        self._image_topic = self.declare_parameter("image_topic", "/image").value
+        self._camera_frame = self.declare_parameter("camera_frame", "camera").value
+        self._distortion_model = self.declare_parameter("distortion_model", "plumb_bob").value
+
+        self._obj_template = self._build_object_points(self._checkerboard, square_size)
+        self._objpoints: List[np.ndarray] = []
+        self._imgpoints: List[np.ndarray] = []
+        self._last_gray_shape: Optional[Tuple[int, int]] = None
+        self._last_header_stamp: Optional[Time] = None
+        self._result: Optional[CalibrationResult] = None
+        self._camera_info: Optional[CameraInfo] = None
+        self._calibration_complete = False
+
+        self._camera_info_pub = self.create_publisher(CameraInfo, "camera_info", 10)
+        self._image_sub = self.create_subscription(Image, self._image_topic, self._handle_image, 10)
+        self.create_service(Trigger, "reset_calibration", self._handle_reset)
+
+        self.get_logger().info(
+            "Listening for images on '%s' with checkerboard %dx%d", self._image_topic, cols, rows
+        )
+
+    @property
+    def calibration_complete(self) -> bool:
+        return self._calibration_complete
+
+    @property
+    def camera_info(self) -> Optional[CameraInfo]:
+        return self._camera_info
+
+    @property
+    def result(self) -> Optional[CalibrationResult]:
+        return self._result
+
+    def _handle_reset(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        self._objpoints.clear()
+        self._imgpoints.clear()
+        self._last_gray_shape = None
+        self._last_header_stamp = None
+        self._result = None
+        self._camera_info = None
+        self._calibration_complete = False
+        response.success = True
+        response.message = "calibration state cleared"
+        self.get_logger().info("Calibration state reset")
+        return response
+
+    def _handle_image(self, msg: Image) -> None:
+        if self._calibration_complete:
+            return
+
+        gray = self._image_to_gray(msg)
+        if gray is None:
+            return
+
+        flags = cv2.CALIB_CB_ADAPTIVE_THRESH | cv2.CALIB_CB_NORMALIZE_IMAGE
+        if self._fast_check:
+            flags |= cv2.CALIB_CB_FAST_CHECK
+
+        found, corners = cv2.findChessboardCorners(gray, self._checkerboard, flags)
+        if not found:
+            self.get_logger().debug("Checkerboard not found in incoming frame")
+            return
+
+        refined = cv2.cornerSubPix(gray, corners, (11, 11), (-1, -1), self._criteria)
+        self._objpoints.append(self._obj_template.copy())
+        self._imgpoints.append(refined)
+        self._last_gray_shape = gray.shape[::-1]
+        self._last_header_stamp = msg.header.stamp
+        self.get_logger().info("Accepted checkerboard frame %d", len(self._imgpoints))
+
+        if len(self._imgpoints) >= self._required_samples:
+            self._perform_calibration()
+
+    def _perform_calibration(self) -> None:
+        if not self._last_gray_shape or not self._imgpoints:
+            self.get_logger().warning("Insufficient data to calibrate")
+            return
+
+        ret, matrix, distortion, rvecs, tvecs = cv2.calibrateCamera(
+            self._objpoints,
+            self._imgpoints,
+            self._last_gray_shape,
+            None,
+            None,
+        )
+        if not ret:
+            self.get_logger().error("Calibration failed")
+            return
+
+        self._result = CalibrationResult(matrix=matrix, distortion=distortion, rvecs=rvecs, tvecs=tvecs)
+        self._publish_camera_info(matrix, distortion)
+        self._calibration_complete = True
+        self.get_logger().info("Calibration succeeded with reprojection error %.4f", ret)
+
+    def _publish_camera_info(self, matrix: np.ndarray, distortion: np.ndarray) -> None:
+        if self._last_gray_shape is None:
+            return
+
+        info = CameraInfo()
+        info.header.stamp = self._last_header_stamp if self._last_header_stamp else Time()
+        info.header.frame_id = self._camera_frame
+        info.width, info.height = self._last_gray_shape
+        info.distortion_model = self._distortion_model
+        info.d = distortion.ravel().tolist()
+        info.k = matrix.reshape(-1).tolist()
+        info.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        info.p = [
+            matrix[0, 0],
+            0.0,
+            matrix[0, 2],
+            0.0,
+            0.0,
+            matrix[1, 1],
+            matrix[1, 2],
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+        ]
+
+        self._camera_info = info
+        self._camera_info_pub.publish(info)
+
+    @staticmethod
+    def _build_object_points(board: Tuple[int, int], square_size: float) -> np.ndarray:
+        cols, rows = board
+        grid = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2).astype(np.float32)
+        objp = np.zeros((grid.shape[0], 3), dtype=np.float32)
+        objp[:, :2] = grid * square_size
+        return objp
+
+    def _image_to_gray(self, msg: Image) -> Optional[np.ndarray]:
+        array = np.frombuffer(msg.data, dtype=np.uint8)
+        if msg.encoding == "mono8":
+            if array.size != msg.height * msg.width:
+                self.get_logger().warning("Invalid mono image payload size")
+                return None
+            return array.reshape((msg.height, msg.width))
+        if msg.encoding in {"bgr8", "rgb8"}:
+            expected = msg.height * msg.width * 3
+            if array.size != expected:
+                self.get_logger().warning("Invalid color image payload size")
+                return None
+            image = array.reshape((msg.height, msg.width, 3))
+            if msg.encoding == "rgb8":
+                image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+            return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        self.get_logger().warning("Unsupported image encoding '%s'", msg.encoding)
+        return None
+
+
+def main(args: Optional[Sequence[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = CheckerboardCalibratorNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/tests/test_checkerboard_calibrator_node.py
+++ b/tests/test_checkerboard_calibrator_node.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import math
+from typing import Iterable, Tuple
+
+import numpy as np
+import pytest
+
+SKIP_KWARGS = {"exc_type": ImportError}
+
+pytest.importorskip("cv2", reason="OpenCV required for calibration tests", **SKIP_KWARGS)
+pytest.importorskip("rclpy", reason="ROS 2 client library required", **SKIP_KWARGS)
+pytest.importorskip("sensor_msgs.msg", reason="ROS 2 message definitions required", **SKIP_KWARGS)
+pytest.importorskip("std_msgs.msg", reason="Standard ROS 2 messages required", **SKIP_KWARGS)
+pytest.importorskip("std_srvs.srv", reason="Standard ROS 2 services required", **SKIP_KWARGS)
+
+import cv2
+import rclpy
+from builtin_interfaces.msg import Time
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import Image
+from std_msgs.msg import Header
+from std_srvs.srv import Trigger
+
+from xnodes.calibration.nodes import CheckerboardCalibratorNode
+
+
+@pytest.fixture(scope="module", autouse=True)
+def rclpy_runtime() -> Iterable[None]:
+    rclpy.init(args=None)
+    yield
+    rclpy.shutdown()
+
+
+def _camera_matrix(focal_length: float, cx: float, cy: float) -> np.ndarray:
+    matrix = np.eye(3, dtype=np.float64)
+    matrix[0, 0] = focal_length
+    matrix[1, 1] = focal_length
+    matrix[0, 2] = cx
+    matrix[1, 2] = cy
+    return matrix
+
+
+def _rotation_matrix(rx: float, ry: float, rz: float) -> np.ndarray:
+    cx, cy, cz = math.cos(rx), math.cos(ry), math.cos(rz)
+    sx, sy, sz = math.sin(rx), math.sin(ry), math.sin(rz)
+    rot_x = np.array([[1.0, 0.0, 0.0], [0.0, cx, -sx], [0.0, sx, cx]])
+    rot_y = np.array([[cy, 0.0, sy], [0.0, 1.0, 0.0], [-sy, 0.0, cy]])
+    rot_z = np.array([[cz, -sz, 0.0], [sz, cz, 0.0], [0.0, 0.0, 1.0]])
+    return rot_z @ rot_y @ rot_x
+
+
+def _render_checkerboard(
+    board: Tuple[int, int],
+    square_size: float,
+    image_size: Tuple[int, int],
+    matrix: np.ndarray,
+    rvec: np.ndarray,
+    tvec: np.ndarray,
+) -> np.ndarray:
+    width, height = image_size
+    image = np.full((height, width), 255, dtype=np.uint8)
+    squares_x, squares_y = board[0] + 1, board[1] + 1
+    for y in range(squares_y):
+        for x in range(squares_x):
+            color = 0 if (x + y) % 2 == 0 else 255
+            square = np.array(
+                [
+                    [x * square_size, y * square_size, 0.0],
+                    [(x + 1) * square_size, y * square_size, 0.0],
+                    [(x + 1) * square_size, (y + 1) * square_size, 0.0],
+                    [x * square_size, (y + 1) * square_size, 0.0],
+                ],
+                dtype=np.float32,
+            )
+            projected, _ = cv2.projectPoints(square, rvec, tvec, matrix, None)
+            polygon = np.round(projected).astype(np.int32)
+            cv2.fillConvexPoly(image, polygon, color)
+    blurred = cv2.GaussianBlur(image, (5, 5), 0)
+    return cv2.cvtColor(blurred, cv2.COLOR_GRAY2BGR)
+
+
+def _image_message(image: np.ndarray, stamp: Time) -> Image:
+    msg = Image()
+    msg.height, msg.width = image.shape[:2]
+    msg.encoding = "bgr8"
+    msg.step = msg.width * 3
+    msg.data = image.tobytes()
+    msg.header = Header()
+    msg.header.frame_id = "camera"
+    msg.header.stamp = stamp
+    return msg
+
+
+def test_calibration_matches_expected_intrinsics() -> None:
+    board = (6, 9)
+    square_size = 0.04
+    width, height = 640, 480
+    focal = 800.0
+    cx, cy = width / 2.0, height / 2.0
+    matrix = _camera_matrix(focal, cx, cy)
+    overrides = [
+        Parameter(name="checkerboard_cols", value=board[0]),
+        Parameter(name="checkerboard_rows", value=board[1]),
+        Parameter(name="square_size", value=square_size),
+        Parameter(name="required_samples", value=8),
+        Parameter(name="image_topic", value="/synthetic"),
+    ]
+    node = CheckerboardCalibratorNode(parameter_overrides=overrides)
+
+    try:
+        for index in range(8):
+            angles = np.deg2rad(np.array([(-5 + index), 2.5 * np.sin(index), 1.5 * np.cos(index)]))
+            rotation = _rotation_matrix(*angles)
+            rvec, _ = cv2.Rodrigues(rotation)
+            tvec = np.array([[0.0], [0.0], [1.2 + 0.02 * index]], dtype=np.float32)
+            image = _render_checkerboard(board, square_size, (width, height), matrix, rvec, tvec)
+            stamp = Time(sec=0, nanosec=index * 1000000)
+            msg = _image_message(image, stamp)
+            node._handle_image(msg)
+
+        assert node.calibration_complete, "Calibration did not complete"
+        camera_info = node.camera_info
+        assert camera_info is not None
+        calibrated = np.array(camera_info.k, dtype=np.float64).reshape(3, 3)
+        np.testing.assert_allclose(calibrated, matrix, rtol=5e-2, atol=1.0)
+        np.testing.assert_allclose(camera_info.d, np.zeros_like(camera_info.d), atol=5e-2)
+    finally:
+        node.destroy_node()
+
+
+def test_reset_clears_internal_state() -> None:
+    overrides = [
+        Parameter(name="required_samples", value=1),
+    ]
+    node = CheckerboardCalibratorNode(parameter_overrides=overrides)
+    try:
+        result = node._handle_reset(Trigger.Request(), Trigger.Response())
+        assert result.success
+        assert node.camera_info is None
+        assert not node.calibration_complete
+    finally:
+        node.destroy_node()


### PR DESCRIPTION
## Summary
- add a ROS 2 checkerboard calibration node that streams images and publishes CameraInfo results
- expose the calibration node package and configure dependencies/pytest defaults
- include synthetic-image based unit tests that exercise the node implementation

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913cb5723fc8329b1050839b9c031bb)