### PR TITLE
Add webpolicy bridge support to OpenCV camera node

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "opencv-contrib-python",
     "numpy",
     "tyro",
+    "webpolicy",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/xnodes/nodes/opencv_camera.py
+++ b/src/xnodes/nodes/opencv_camera.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import copy
 from dataclasses import dataclass, field
 import enum
@@ -11,6 +12,7 @@ from urllib.parse import urlparse
 from ament_index_python.packages import get_package_share_directory
 import cv2
 from cv_bridge import CvBridge
+import numpy as np
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
@@ -18,6 +20,7 @@ from rich import print
 from sensor_msgs.msg import CameraInfo, Image
 import tyro
 import yaml
+from webpolicy.client import Client
 
 
 class RES(enum.Enum):
@@ -35,12 +38,16 @@ class RES(enum.Enum):
 @dataclass
 class CamConfig:
     device: str = "/dev/video0"
+    video_id: int = -1
     image_size: Sequence[int] = field(default_factory=lambda: [640, 480])
     output_encoding: str = "bgr8"
     camera_name: str = "camera"
     frame_id: str = "camera_optical_frame"
     fps: float = 30.0
     camera_info_url: str = ""
+    attr: str = ""
+    webpolicy_host: str | None = None
+    webpolicy_port: int | None = None
 
 
 class OpenCVCameraNode(Node):
@@ -51,45 +58,54 @@ class OpenCVCameraNode(Node):
         self.bridge = CvBridge()
 
         if cfg is None:
-            self.video_device = self.declare_parameter("video_device", "/dev/video0").value
-            self.video_id = int(self.declare_parameter("video_id", -1).value)
-            self.encoding = self.declare_parameter("output_encoding", "bgr8").value
-            self.camera_name = self.declare_parameter("camera_name", "camera").value
-            self.frame_id = self.declare_parameter("frame_id", f"{self.camera_name}_optical_frame").value
-            self.fps = float(self.declare_parameter("fps", 30.0).value)
-            self.camera_info_url = self.declare_parameter("camera_info_url", "").value
-
-            self.width = self.declare_parameter("width", 640).value
-            self.height = self.declare_parameter("height", 480).value
-
-        # self.width, self.height = self._parse_image_size(image_size)
-
-        device = self.video_device if self.video_id < 0 else self.video_id
-        self.device = self._normalize_device_name(device)
-
-        self.cfg = (
-            CamConfig(
-                device=device,
-                image_size=[self.width, self.height],
-                output_encoding=self.encoding,
-                camera_name=self.camera_name,
-                frame_id=self.frame_id,
-                fps=self.fps,
-                camera_info_url=self.camera_info_url,
+            video_device = self.declare_parameter("video_device", "/dev/video0").value
+            video_id = int(self.declare_parameter("video_id", -1).value)
+            width = int(self.declare_parameter("width", 640).value)
+            height = int(self.declare_parameter("height", 480).value)
+            camera_name = self.declare_parameter("camera_name", "camera").value
+            cfg = CamConfig(
+                device=video_device if video_id < 0 else str(video_id),
+                video_id=video_id,
+                image_size=[width, height],
+                output_encoding=self.declare_parameter("output_encoding", "bgr8").value,
+                camera_name=camera_name,
+                frame_id=self.declare_parameter("frame_id", f"{camera_name}_optical_frame").value,
+                fps=float(self.declare_parameter("fps", 30.0).value),
+                camera_info_url=self.declare_parameter("camera_info_url", "").value,
+                attr=self.declare_parameter("attr", "").value,
+                webpolicy_host=self.declare_parameter("webpolicy_host", "").value,
+                webpolicy_port=int(self.declare_parameter("webpolicy_port", 0).value),
             )
-            if cfg is None
-            else cfg
-        )
+
+        self.cfg = cfg
+        self.encoding = self.cfg.output_encoding
+        self.camera_name = self.cfg.camera_name
+        self.frame_id = self.cfg.frame_id
+        self.fps = float(self.cfg.fps)
+        self.camera_info_url = self.cfg.camera_info_url
+        self.width, self.height = self._parse_image_size(self.cfg.image_size)
+        self.video_id = int(self.cfg.video_id)
+        self.attr = self.cfg.attr
+        self.webpolicy_host = (self.cfg.webpolicy_host or "").strip()
+        self.webpolicy_port = int(self.cfg.webpolicy_port or 0)
+
+        device_name = self.video_id if self.video_id >= 0 else self.cfg.device
+        self.device = self._normalize_device_name(device_name)
         print(self.cfg)
 
-        self.cap = self._open_camera(self.cfg.device)
-        self.cap.set(cv2.CAP_PROP_AUTOFOCUS, 0)
-        self.cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1)
-        if self.width > 0 and self.height > 0:
-            self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, float(self.width))
-            self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, float(self.height))
-        if self.fps > 0:
-            self.cap.set(cv2.CAP_PROP_FPS, float(self.fps))
+        self.cap: cv2.VideoCapture | None = None
+        self.web_client: Client | None = None
+        if self.attr == "bridge:web":
+            self._init_webpolicy_client()
+        else:
+            self.cap = self._open_camera(self.cfg.device)
+            self.cap.set(cv2.CAP_PROP_AUTOFOCUS, 0)
+            self.cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1)
+            if self.width > 0 and self.height > 0:
+                self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, float(self.width))
+                self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, float(self.height))
+            if self.fps > 0:
+                self.cap.set(cv2.CAP_PROP_FPS, float(self.fps))
 
         qos = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -97,7 +113,7 @@ class OpenCVCameraNode(Node):
             depth=5,
         )
 
-        prefix = f"cam/c{device}"
+        prefix = f"cam/c{self.device}"
         self.image_pub = self.create_publisher(Image, f"{prefix}/image_raw", qos)
         self.info_pub = self.create_publisher(CameraInfo, f"{prefix}/camera_info", qos)
 
@@ -124,11 +140,20 @@ class OpenCVCameraNode(Node):
         return int(value[0]), int(value[1])
 
     def _open_camera(self, device: str) -> cv2.VideoCapture:
-        device = int(device) if isinstance(device, int) or device.isdigit() else device
+        device = int(device) if isinstance(device, int) or str(device).isdigit() else device
         cap = cv2.VideoCapture(device)
         if not cap.isOpened():
             raise RuntimeError(f"Failed to open camera {device}")
         return cap
+
+    def _init_webpolicy_client(self) -> None:
+        if not self.webpolicy_host or self.webpolicy_port <= 0:
+            raise ValueError("webpolicy_host and webpolicy_port are required when attr == 'bridge:web'")
+        self.video_id = self.video_id if self.video_id >= 0 else 0
+        self.web_client = Client(host=self.webpolicy_host, port=self.webpolicy_port)
+        self.get_logger().info(
+            f"Using webpolicy bridge at {self.webpolicy_host}:{self.webpolicy_port} for camera id {self.video_id}"
+        )
 
     def _load_camera_info(self) -> CameraInfo:
         url = self.camera_info_url
@@ -173,14 +198,8 @@ class OpenCVCameraNode(Node):
         return info
 
     def _tick(self) -> None:
-        if not self.cap.isOpened():
-            self.get_logger().warn("Camera closed; stopping timer")
-            self.timer.cancel()
-            return
-
-        ok, frame = self.cap.read()
-        if not ok:
-            self.get_logger().warn("Failed to grab frame", throttle_duration_sec=5.0)
+        frame = self._read_frame()
+        if frame is None:
             return
 
         frame = self._ensure_size(frame)
@@ -194,6 +213,50 @@ class OpenCVCameraNode(Node):
         self._populate_camera_info(info, frame)
         info.header = image.header
         self.info_pub.publish(info)
+
+    def _read_frame(self):
+        if self.cap is not None:
+            if not self.cap.isOpened():
+                self.get_logger().warn("Camera closed; stopping timer")
+                self.timer.cancel()
+                return None
+            ok, frame = self.cap.read()
+            if not ok:
+                self.get_logger().warn("Failed to grab frame", throttle_duration_sec=5.0)
+                return None
+            return frame
+
+        if self.web_client is None:
+            self.get_logger().warn("No capture source available", throttle_duration_sec=5.0)
+            return None
+
+        try:
+            response = self.web_client.step({"id": self.video_id})
+        except Exception as exc:  # pragma: no cover - depends on network
+            self.get_logger().warn(f"Webpolicy request failed: {exc}", throttle_duration_sec=5.0)
+            return None
+
+        frame = self._decode_webpolicy_frame(response)
+        if frame is None:
+            self.get_logger().warn("Webpolicy response did not contain a valid image", throttle_duration_sec=5.0)
+        return frame
+
+    def _decode_webpolicy_frame(self, response):
+        payload = response.get("image") if isinstance(response, dict) else response
+        if isinstance(payload, bytes | bytearray):
+            data = bytes(payload)
+        elif isinstance(payload, str):
+            try:
+                data = base64.b64decode(payload)
+            except Exception:
+                return None
+        elif isinstance(payload, np.ndarray):
+            return payload
+        else:
+            return None
+
+        buffer = np.frombuffer(data, dtype=np.uint8)
+        return cv2.imdecode(buffer, cv2.IMREAD_COLOR)
 
     def _ensure_size(self, frame):
         h, w = frame.shape[:2]
@@ -246,7 +309,7 @@ class OpenCVCameraNode(Node):
         return name
 
     def destroy_node(self) -> None:
-        if self.cap.isOpened():
+        if self.cap is not None and self.cap.isOpened():
             self.cap.release()
         super().destroy_node()
 


### PR DESCRIPTION
## Summary
- add a webpolicy bridge mode to the OpenCV camera node with remote frame decoding
- extend camera configuration to carry web bridge host/port and video id options
- declare the webpolicy client dependency for packaging

## Testing
- python -m compileall src/xnodes/nodes/opencv_camera.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227f564c3883298753d6f265921bd2)